### PR TITLE
Write dirty

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dirty"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Tom Burdick <thomas.burdick@gmail.com>"]
 description = "Holds a value with a dirty flag which is set on writes and cleared on clear()"
 documentation = "https://bfrog.github.io/dirty"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,13 @@ impl<T> Dirty<T> {
         }
     }
 
+    /// Write new value only if dirty, returning whether the value was written or not
+    pub fn write_dirty<F>(&mut self, f: F) -> bool
+    where F: Fn(&T) -> T {
+        if self.dirty { self.value = f(&self.value); }
+        self.dirty
+    }
+
     /// Consumes the wrapper and returns the enclosed value
     pub fn unwrap(self) -> T {
         self.value
@@ -116,6 +123,15 @@ mod tests {
         dirty.clear();
         assert!(!dirty.dirty());
         assert!(dirty.read_dirty() == None);
+    }
+
+    #[test]
+    fn write_dirty() {
+        let mut dirty = Dirty::new_clean(0);
+        assert!(!dirty.write_dirty(|_| 3));
+        *dirty.write() += 3;
+        assert!(dirty.write_dirty(|_| [1, 2, 3].iter().copied().reduce(|acc, x| acc + x).unwrap()));
+        assert_eq!(*dirty.read(), 6);
     }
 
     #[test]


### PR DESCRIPTION
This PR adds a simple function that both checks dirty and update the value when true.
The function takes a closure as argument so lazy evaluations are only calculated when necessary.